### PR TITLE
Update alt-image-text to include a more accurate text replacement method

### DIFF
--- a/data/alt-image-text.md
+++ b/data/alt-image-text.md
@@ -1,9 +1,10 @@
 ### Images with text should be accessible to screen readers
 
-Images that contain text in them such as logos should make that text available to screen readers in some form. The most straightforward way to do this is to style a `header` element as image and use `text-indent: -9999px` as its text content.
+Images that contain text in them such as logos should make that text available to screen readers in some form. You should have an appropriate element in the HTML that contains the text, then place the image through the CSS `background-image` attribute. There are many methods to hide the text, buy typically you can use a combination of `color: transparent`, `overflow: hidden`, and `user-select: none`.
 
 ### Resources
 <!-- Whenever possible, include the links to more advanced guide-->
+* [The Image Replacement Museum](https://css-tricks.com/the-image-replacement-museum/)
 
 <!-- category: (0)-->
 <!-- available categories:


### PR DESCRIPTION
Second try, this should be a cleaner pull request.

Updated the alt-image-text tip to include safer methods than `text-indent: -9999px`, as this can introduce performance issues with rendering and animations.